### PR TITLE
Update cleanup, skipp removing /root/.bashrc file

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -39,6 +39,5 @@ clean_machine() {
     rm -rf \
         /root/.bash_history \
         /root/.viminfo \
-        /root/.bashrc \
         /root/.cache
 }

--- a/tasks/google/update-fedora-27-selinux-enforcing/task.yaml
+++ b/tasks/google/update-fedora-27-selinux-enforcing/task.yaml
@@ -21,6 +21,7 @@ execute: |
         REBOOT
     fi
 
+    # Set selinux as permissive
     sed -i 's/SELINUX=.*/SELINUX=enforcing/g' /etc/selinux/config
 
     # Clean disk before create the shapshot

--- a/tasks/google/update-fedora-27-selinux-permissive/task.yaml
+++ b/tasks/google/update-fedora-27-selinux-permissive/task.yaml
@@ -21,6 +21,7 @@ execute: |
         REBOOT
     fi
 
+    # Set selinux as permissive
     sed -i 's/SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config
 
     # Clean disk before create the shapshot

--- a/tasks/google/update-fedora-28-selinux-permissive/task.yaml
+++ b/tasks/google/update-fedora-28-selinux-permissive/task.yaml
@@ -21,6 +21,7 @@ execute: |
         REBOOT
     fi
 
+    # Set selinux as permissive
     sed -i 's/SELINUX=.*/SELINUX=permissive/g' /etc/selinux/config
 
     # Clean disk before create the shapshot


### PR DESCRIPTION
The /root/.bashrc file is not removed any more due to it contains umask
configuration which is useful.