### PR TITLE
tasks/google/update-arch-linux: tweak Arch image update

### DIFF
--- a/tasks/google/update-arch-linux/task.yaml
+++ b/tasks/google/update-arch-linux/task.yaml
@@ -12,25 +12,38 @@ execute: |
     . "$TESTSLIB/utils.sh"
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
+        # remove the user account that was present in the base image
+        userdel -r -f alrii14344 || true
+
+        # Fix shadow.service by creating missing home dirs for users
+        if [ ! -d /home/user ]; then
+            mkdir -p /home/user
+            chown -R user:user /home/user
+            mkdir -p /home/guest
+            chown -R guest:guest /home/guest
+            systemctl restart shadow.service
+        fi
+
         # Make the upgrade
         distro_update_package_db
         distro_upgrade_packages
         install_test_dependencies "$TARGET_SYSTEM"
         remove_pkg_blacklist
+
         distro_install_google_compute_engine
+        # Disable google-shutdown-scripts service because it hungs during reboot
+        systemctl disable --now google-shutdown-scripts.service
+
         distro_clean_package_cache
+
+        # since 4.16, kernel crng init can take significant time, thus services
+        # depending on crypto such as sshd will take longer to start
+        distro_install_package haveged
+        systemctl enable --now haveged
+
         REBOOT
     fi
 
-    # Fix shadow.service by creating missing home dirs for users
-    if [ ! -d /home/user ]; then
-        mkdir -p /home/user
-        mkdir -p /home/guest
-        systemctl restart shadow.service
-    fi
-
-    # Disable google-shutdown-scripts service because it hungs during reboot
-    systemctl disable google-shutdown-scripts.service
 
     # Clean disk before create the shapshot
     clean_machine


### PR DESCRIPTION
Update Arch image upgrade process to properly use the gce-compute-image-packages
from AUR instead of hand building one.

Also, make sure that google-shutdown-scripts.service is disabled *before* the
first reboot. The service hangs and has TimeoutStopSec=0 meaning shutdown will
hand indefinitely.

Since 4.16 kernel crng initialization can take significant time, thus affecting
services such as sshd. In testing, the crng init was done after ~10 minutes from
machine being up. Since sshd started actually listening after crng was done, the
machine appeared offline. As a workaround install haveged to speed up the rng
initialization.

(cc @sergiocazzolato )