### PR TITLE
tasks/google/update-arch-linux: update archlinux-keyring before other packages

### DIFF
--- a/tasks/google/update-arch-linux/task.yaml
+++ b/tasks/google/update-arch-linux/task.yaml
@@ -25,8 +25,9 @@ execute: |
         fi
 
         # Make the upgrade
-        pacman-key --populate
         distro_update_package_db
+        # update the keyring first to account for expired keys
+        pacman -S --noconfirm archlinux-keyring
         distro_upgrade_packages
         install_test_dependencies "$TARGET_SYSTEM"
         remove_pkg_blacklist


### PR DESCRIPTION
The archlinux-keyring package needs to be updated before any other packages.
Otherwise, the package signing keys will be outdated and package integrity
validation may fail.
