### PR TITLE
tasks/openstack/update-image/opensuse-tumbleweed-64: update bootloader after switching to AppArmor

### DIFF
--- a/tasks/openstack/update-image/opensuse-tumbleweed-64/task.yaml
+++ b/tasks/openstack/update-image/opensuse-tumbleweed-64/task.yaml
@@ -34,6 +34,7 @@ execute: |
         zypper in -y --type pattern apparmor
 
         sed -i -e 's/security=selinux/security=apparmor/g' -e 's/selinux=1//g' /etc/default/grub
+        update-bootloader
 
         remove_pkg_blacklist
 


### PR DESCRIPTION
Run update-bootloader to make the changes effective.