### PR TITLE
Deactivate openstack image when it fails to be deleted

### DIFF
--- a/lib/openstack.sh
+++ b/lib/openstack.sh
@@ -340,7 +340,10 @@ update_image(){
     # delete the image is failed to start
     if [ "$start_failed" == "true" ]; then
         echo "Deleting image that failed to start after the update"
-        openstack image delete "$target_id"
+        if ! openstack image delete "$target_id"; then
+            echo "Failed to delete image, deactivating instead"
+            openstack image set --deactivate "$target_id"
+        fi
     fi
 
     # check spread and os commands didn't fail


### PR DESCRIPTION
This is to avoid having active an image which is failing to boot and cannot be removed