### PR TITLE
New images for ubuntu trusty and {24,26}-nested

### DIFF
--- a/lib/openstack.sh
+++ b/lib/openstack.sh
@@ -33,6 +33,7 @@ show_help_add() {
     echo "./lib/openstack.sh add-image --backend openstack --task opensuse-15.6-64 --target-system opensuse-15.6-64-base"
     echo "./lib/openstack.sh add-image --backend openstack --task opensuse-16.0-64 --target-system opensuse-16.0-64-base"
     echo "./lib/openstack.sh add-image --backend openstack --task opensuse-tumbleweed-64 --target-system opensuse-tumbleweed-64-base"
+    echo "./lib/openstack.sh add-image --backend openstack --task ubuntu-14.04-64 --target-system ubuntu-14.04-64-base"
     echo "./lib/openstack.sh add-image --backend openstack --task ubuntu-25.10-64 --target-system ubuntu-25.10-64-base"
 }
 
@@ -63,6 +64,7 @@ show_help_update() {
     echo "./lib/openstack.sh update-image --backend openstack --task opensuse-tumbleweed-64-selinux --source-system opensuse-tumbleweed-64-base --target-system opensuse-tumbleweed-64-selinux-enabled"
     echo ""
     echo "examples for ubuntu images:"
+    echo "./lib/openstack.sh update-image --backend openstack --task ubuntu-14.04-64 --source-system ubuntu-14.04-64-base --target-system ubuntu-14.04-64"
     echo "./lib/openstack.sh update-image --backend openstack --task ubuntu-16.04-64 --source-system ubuntu-16.04-64-base --target-system ubuntu-16.04-64"
     echo "./lib/openstack.sh update-image --backend openstack --task ubuntu-18.04-64 --source-system ubuntu-18.04-64-base --target-system ubuntu-18.04-64"
     echo "./lib/openstack.sh update-image --backend openstack --task ubuntu-20.04-64 --source-system ubuntu-20.04-64-base --target-system ubuntu-20.04-64"
@@ -99,6 +101,12 @@ show_help_update() {
     echo "./lib/openstack.sh update-image --backend openstack-arm --task ubuntu-22.04-arm-64 --source-system ubuntu-22.04-arm-64-base --target-system ubuntu-22.04-arm-64-uefi --property hw_firmware_type=uefi"
     echo "./lib/openstack.sh update-image --backend openstack-arm --task ubuntu-24.04-arm-64 --source-system ubuntu-24.04-arm-64-base --target-system ubuntu-24.04-arm-64-uefi --property hw_firmware_type=uefi"
     echo "./lib/openstack.sh update-image --backend openstack-arm --task ubuntu-26.04-arm-64 --source-system ubuntu-26.04-arm-64-base --target-system ubuntu-26.04-arm-64-uefi --property hw_firmware_type=uefi"
+    echo ""
+    echo "examples for ubuntu images for nested tests:"
+    echo "./lib/openstack.sh update-image --backend openstack --task ubuntu-24.04-64-nested --source-system ubuntu-24.04-64-base --target-system ubuntu-24.04-64-nested"
+    echo "./lib/openstack.sh update-image --backend openstack --task ubuntu-26.04-64-nested --source-system ubuntu-26.04-64-base --target-system ubuntu-26.04-64-nested"
+    echo "./lib/openstack.sh update-image --backend openstack-arm --task ubuntu-24.04-arm-64-nested --source-system ubuntu-24.04-arm-64-base --target-system ubuntu-24.04-arm-64-nested"
+    echo "./lib/openstack.sh update-image --backend openstack-arm --task ubuntu-26.04-arm-64-nested --source-system ubuntu-26.04-arm-64-base --target-system ubuntu-26.04-arm-64-nested"
     echo ""
     echo "examples for base images:"
     echo "./lib/openstack.sh update-image --backend openstack --task opensuse-15.5-64-base --source-system opensuse-15.5-64-base --target-system opensuse-15.5-64-base"

--- a/spread.yaml
+++ b/spread.yaml
@@ -221,6 +221,10 @@ backends:
             NO_PROXY: '127.0.0.1'
             NTP_SERVER: 'ntp.ps7.internal'
         systems: &openstack-systems
+            - ubuntu-14.04-64-base:
+                image: snapd-base/ubuntu-14.04-64-base
+            - ubuntu-14.04-64:
+                image: snapd-spread/ubuntu-14.04-64
             - ubuntu-16.04-64-base:
                 image: auto-sync/ubuntu-xenial-16.04-amd64-server
             - ubuntu-16.04-64:
@@ -259,6 +263,8 @@ backends:
                 image: snapd-spread/ubuntu-24.04-64-secboot
             - ubuntu-24.04-64-pro-fips-enabled:
                 image: snapd-spread/ubuntu-24.04-64-pro-fips
+            - ubuntu-24.04-64-nested:
+                image: snapd-spread/ubuntu-24.04-64-nested
             - ubuntu-25.04-64-base:
                 image: auto-sync/ubuntu-plucky-25.04-amd64-server
             - ubuntu-25.04-64:
@@ -275,6 +281,8 @@ backends:
                 image: snapd-spread/ubuntu-26.04-64-uefi
             - ubuntu-26.04-64-pro-fips-enabled:
                 image: snapd-spread/ubuntu-26.04-64-pro-fips
+            - ubuntu-26.04-64-nested:
+                image: snapd-spread/ubuntu-26.04-64-nested
 
             - ubuntu-core-20-64:
                 image: snapd-spread/ubuntu-20.04-64-uefi
@@ -384,12 +392,16 @@ backends:
                 image: snapd-spread/ubuntu-24.04-arm-64
             - ubuntu-24.04-arm-64-uefi:
                 image: snapd-spread/ubuntu-24.04-arm-64-uefi
+            - ubuntu-24.04-arm-64-nested:
+                image: snapd-spread/ubuntu-24.04-arm-64-nested
             - ubuntu-26.04-arm-64-base:
                 image: auto-sync/ubuntu-resolute-daily-arm64-server
             - ubuntu-26.04-arm-64:
                 image: snapd-spread/ubuntu-26.04-arm-64
             - ubuntu-26.04-arm-64-uefi:
                 image: snapd-spread/ubuntu-26.04-arm-64-uefi
+            - ubuntu-26.04-arm-64-nested:
+                image: snapd-spread/ubuntu-26.04-arm-64-nested
 
     openstack-stg:
         type: openstack

--- a/tasks/openstack/add-image/ubuntu-14.04-64/task.yaml
+++ b/tasks/openstack/add-image/ubuntu-14.04-64/task.yaml
@@ -1,0 +1,17 @@
+summary: Add ubuntu 14.04 image
+
+systems: [ubuntu-*]
+
+environment:
+    IMAGE_URL: '$(HOST: echo "${SPREAD_IMAGE_URL:-https://cloud-images.ubuntu.com/releases/trusty/release/ubuntu-14.04-server-cloudimg-amd64-disk1.img}")'
+    IMAGE_NAME: '$(HOST: echo "${SPREAD_IMAGE_NAME:-trusty-server-cloudimg-amd64.qcow2}")'
+
+execute: |
+    source_image_name="$(basename $IMAGE_URL)"
+    wget -q -O "$IMAGE_NAME" "$IMAGE_URL"
+
+    gsutil cp "$IMAGE_NAME" gs://snapd-spread-tests/images/openstack/"$IMAGE_NAME"
+
+restore: |
+    # Remove the project path content
+    rm -rf "$PROJECT_PATH"

--- a/tasks/openstack/update-image/ubuntu-14.04-64/task.yaml
+++ b/tasks/openstack/update-image/ubuntu-14.04-64/task.yaml
@@ -1,0 +1,34 @@
+summary: Update Ubuntu 14.04 64 bits image with the latest updates
+
+systems: [ubuntu-14.04-64-base]
+
+environment:
+    TARGET_SYSTEM: ubuntu-14.04-64
+
+execute: |
+    . "$TESTSLIB/pkgdb.sh"
+    . "$TESTSLIB/utils.sh"
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # Make the upgrade and install the dependencies needed to run snapd tests
+        distro_update_package_db
+        distro_upgrade_packages
+
+        install_pkg_dependencies
+        install_test_dependencies "$TARGET_SYSTEM"
+
+        remove_pkg_blacklist
+
+        REBOOT
+    fi
+
+    # Avoid checking for new release, it could cause lock on apt
+    sed -i 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
+
+    # Clean the disk
+    clean_machine
+
+restore: |
+    # Remove the project path content
+    rm -rf "$PROJECT_PATH"
+    sync

--- a/tasks/openstack/update-image/ubuntu-24.04-64-nested/task.yaml
+++ b/tasks/openstack/update-image/ubuntu-24.04-64-nested/task.yaml
@@ -1,0 +1,46 @@
+summary: Update Ubuntu 24.04 64 bits image with the latest updates for nested tests
+
+systems: [ubuntu-24.04-64-base]
+
+kill-timeout: 40m
+
+environment:
+    TARGET_SYSTEM: ubuntu-24.04-64-nested
+    NESTED_TYPE: core
+
+execute: |
+    . "$TESTSLIB/pkgdb.sh"
+    . "$TESTSLIB/utils.sh"
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # Make the upgrade and install the dependencies needed to run snapd tests
+        distro_update_package_db
+        distro_upgrade_packages
+
+        install_pkg_dependencies
+        install_test_dependencies "$TARGET_SYSTEM"
+
+        remove_pkg_blacklist
+
+        REBOOT
+    fi
+
+    # Avoid checking for new release, it could cause lock on apt
+    sed -i 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
+
+    # Disable daily checks for updates to avoid apt locks
+    sudo systemctl disable --now apt-daily{,-upgrade}.{timer,service}
+
+    # Disable the service because sometimes is failing
+    systemctl disable --now fwupd.service fwupd-refresh.service fwupd-refresh.timer
+
+    # Setup ntp server depending on the openstack environment
+    update_ntp
+
+    # Clean disk before create the shapshot
+    clean_machine
+
+restore: |
+    # Remove the project path content
+    rm -rf "$PROJECT_PATH"
+    sync

--- a/tasks/openstack/update-image/ubuntu-24.04-arm-64-nested/task.yaml
+++ b/tasks/openstack/update-image/ubuntu-24.04-arm-64-nested/task.yaml
@@ -1,0 +1,46 @@
+summary: Update Ubuntu 24.04 64 bits image with the latest updates for nested tests
+
+systems: [ubuntu-24.04-arm-64-base]
+
+kill-timeout: 40m
+
+environment:
+    TARGET_SYSTEM: ubuntu-24.04-arm-64-nested
+    NESTED_TYPE: core
+
+execute: |
+    . "$TESTSLIB/pkgdb.sh"
+    . "$TESTSLIB/utils.sh"
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # Make the upgrade and install the dependencies needed to run snapd tests
+        distro_update_package_db
+        distro_upgrade_packages
+
+        install_pkg_dependencies
+        install_test_dependencies "$TARGET_SYSTEM"
+
+        remove_pkg_blacklist
+
+        REBOOT
+    fi
+
+    # Avoid checking for new release, it could cause lock on apt
+    sed -i 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
+
+    # Disable daily checks for updates to avoid apt locks
+    sudo systemctl disable --now apt-daily{,-upgrade}.{timer,service}
+
+    # Disable the service because sometimes is failing
+    systemctl disable --now fwupd.service fwupd-refresh.service fwupd-refresh.timer
+
+    # Setup ntp server depending on the openstack environment
+    update_ntp
+
+    # Clean disk before create the shapshot
+    clean_machine
+
+restore: |
+    # Remove the project path content
+    rm -rf "$PROJECT_PATH"
+    sync

--- a/tasks/openstack/update-image/ubuntu-26.04-64-nested/task.yaml
+++ b/tasks/openstack/update-image/ubuntu-26.04-64-nested/task.yaml
@@ -1,0 +1,46 @@
+summary: Update Ubuntu 26.04 64 bits image with the latest updates for nested tests
+
+systems: [ubuntu-26.04-64-base]
+
+kill-timeout: 40m
+
+environment:
+    TARGET_SYSTEM: ubuntu-26.04-64-nested
+    NESTED_TYPE: core
+
+execute: |
+    . "$TESTSLIB/pkgdb.sh"
+    . "$TESTSLIB/utils.sh"
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # Make the upgrade and install the dependencies needed to run snapd tests
+        distro_update_package_db
+        distro_upgrade_packages
+
+        install_pkg_dependencies
+        install_test_dependencies "$TARGET_SYSTEM"
+
+        remove_pkg_blacklist
+
+        REBOOT
+    fi
+
+    # Avoid checking for new release, it could cause lock on apt
+    sed -i 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
+
+    # Disable daily checks for updates to avoid apt locks
+    sudo systemctl disable --now apt-daily{,-upgrade}.{timer,service}
+
+    # Disable the service because sometimes is failing
+    systemctl disable --now fwupd.service fwupd-refresh.service fwupd-refresh.timer
+
+    # Setup ntp server depending on the openstack environment
+    update_ntp
+
+    # Clean disk before create the shapshot
+    clean_machine
+
+restore: |
+    # Remove the project path content
+    rm -rf "$PROJECT_PATH"
+    sync

--- a/tasks/openstack/update-image/ubuntu-26.04-arm-64-nested/task.yaml
+++ b/tasks/openstack/update-image/ubuntu-26.04-arm-64-nested/task.yaml
@@ -1,0 +1,46 @@
+summary: Update Ubuntu 26.04 64 bits image with the latest updates for nested tests
+
+systems: [ubuntu-26.04-arm-64-base]
+
+kill-timeout: 40m
+
+environment:
+    TARGET_SYSTEM: ubuntu-26.04-arm-64-nested
+    NESTED_TYPE: core
+
+execute: |
+    . "$TESTSLIB/pkgdb.sh"
+    . "$TESTSLIB/utils.sh"
+
+    if [ "$SPREAD_REBOOT" = 0 ]; then
+        # Make the upgrade and install the dependencies needed to run snapd tests
+        distro_update_package_db
+        distro_upgrade_packages
+
+        install_pkg_dependencies
+        install_test_dependencies "$TARGET_SYSTEM"
+
+        remove_pkg_blacklist
+
+        REBOOT
+    fi
+
+    # Avoid checking for new release, it could cause lock on apt
+    sed -i 's/^Prompt=.*$/Prompt=never/' /etc/update-manager/release-upgrades
+
+    # Disable daily checks for updates to avoid apt locks
+    sudo systemctl disable --now apt-daily{,-upgrade}.{timer,service}
+
+    # Disable the service because sometimes is failing
+    systemctl disable --now fwupd.service fwupd-refresh.service fwupd-refresh.timer
+
+    # Setup ntp server depending on the openstack environment
+    update_ntp
+
+    # Clean disk before create the shapshot
+    clean_machine
+
+restore: |
+    # Remove the project path content
+    rm -rf "$PROJECT_PATH"
+    sync


### PR DESCRIPTION
Scripts used to add and update images for ubuntu trusty in openstack

Scripts used to create nested images used for arm64 and amd64, the idea
of those is to preinstall dependencies needed for nested tests using the
NESTED_TYPE env var