### PR TITLE
fix testflinger clean job

### DIFF
--- a/.github/workflows/spread_cleaner_testflinger.yaml
+++ b/.github/workflows/spread_cleaner_testflinger.yaml
@@ -28,8 +28,12 @@ jobs:
 
     - name: Run cleanup
       shell: bash
+      env: 
+          TESTFLINGER_CLIENT_ID: ${{ secrets.TESTFLINGER_CLIENT_ID }}
+          TESTFLINGER_SECRET_KEY: ${{ secrets.TESTFLINGER_SECRET_KEY }}
+          no_proxy: testflinger.canonical.com
       run: |
           cd ./cleaner/testflinger          
-          no_proxy=testflinger.canonical.com spread -gc
+          spread -gc
 
     


### PR DESCRIPTION
Testflinger backend needs client id and secret to connect to the backend now. 