### PR TITLE
lib/pkgdb: appropriate commands for upgrading the distro on Fedora and openSUSE

### DIFF
--- a/lib/pkgdb.sh
+++ b/lib/pkgdb.sh
@@ -321,7 +321,7 @@ distro_upgrade_packages() {
             dnf upgrade --nogpgcheck -y
             ;;
         opensuse-*)
-            zypper update -y --force-resolution --no-recommends --replacefiles
+            zypper dup -y --force-resolution --no-recommends --replacefiles
             ;;
         arch-*)
             pacman --needed --noconfirm -Syu

--- a/lib/pkgdb.sh
+++ b/lib/pkgdb.sh
@@ -318,7 +318,7 @@ distro_upgrade_packages() {
             apt upgrade -y
             ;;
         fedora-*)
-            dnf upgrade --nogpgcheck -y
+            dnf distro-sync --nogpgcheck -y
             ;;
         opensuse-*)
             zypper dup -y --force-resolution --no-recommends --replacefiles


### PR DESCRIPTION
`zypper dup` should be used for whole-system upgrades, and similarly `dnf distro-sync` on Fedora