### PR TITLE
Use default repos in tumbleweed

### DIFF
--- a/tasks/openstack/update-image/opensuse-tumbleweed-64-base/task.yaml
+++ b/tasks/openstack/update-image/opensuse-tumbleweed-64-base/task.yaml
@@ -13,15 +13,15 @@ execute: |
     selinuxenabled
 
     if [ "$SPREAD_REBOOT" = 0 ]; then
-        # Use mirrorcache avoids errors trying to access the repo metadata
+        # Using default repos, but keep the code used to enable repos in case we need to use it
         # Back Up Your Current Repositories
-        cp -r /etc/zypp/repos.d /etc/zypp/repos.d.bak
+        #cp -r /etc/zypp/repos.d /etc/zypp/repos.d.bak
         # Remove the Existing Tumbleweed Repositories
-        zypper rr repo-oss repo-non-oss repo-update
+        #zypper rr repo-oss repo-non-oss repo-update
         # Add repos
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/oss/ repo-oss
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/non-oss/ repo-non-oss
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/update/tumbleweed/ repo-update
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/oss/ repo-oss
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/non-oss/ repo-non-oss
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/update/tumbleweed/ repo-update
 
         # Make the upgrade and install the dependencies needed to run snapd tests
         # In case some repo cannot be updated due to proxy restriction

--- a/tasks/openstack/update-image/opensuse-tumbleweed-64-selinux/task.yaml
+++ b/tasks/openstack/update-image/opensuse-tumbleweed-64-selinux/task.yaml
@@ -13,15 +13,15 @@ execute: |
         # the image has SELinux enabled by default
         selinuxenabled
 
-        # Use mirrorcache avoids errors trying to access the repo metadata
+        # Using default repos, but keep the code used to enable repos in case we need to use it
         # Back Up Your Current Repositories
-        cp -r /etc/zypp/repos.d /etc/zypp/repos.d.bak
+        #cp -r /etc/zypp/repos.d /etc/zypp/repos.d.bak
         # Remove the Existing Tumbleweed Repositories
-        zypper rr repo-oss repo-non-oss repo-update
+        #zypper rr repo-oss repo-non-oss repo-update
         # Add repos
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/oss/ repo-oss
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/non-oss/ repo-non-oss
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/update/tumbleweed/ repo-update
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/oss/ repo-oss
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/non-oss/ repo-non-oss
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/update/tumbleweed/ repo-update
 
         # Make the upgrade and install the dependencies needed to run snapd tests
         # In case some repo cannot be updated due to proxy restriction

--- a/tasks/openstack/update-image/opensuse-tumbleweed-64/task.yaml
+++ b/tasks/openstack/update-image/opensuse-tumbleweed-64/task.yaml
@@ -13,15 +13,15 @@ execute: |
         # the image has SELinux enabled by default
         selinuxenabled
 
-        # Use mirrorcache avoids errors trying to access the repo metadata
+        # Using default repos, but keep the code used to enable repos in case we need to use it
         # Back Up Your Current Repositories
-        cp -r /etc/zypp/repos.d /etc/zypp/repos.d.bak
+        #cp -r /etc/zypp/repos.d /etc/zypp/repos.d.bak
         # Remove the Existing Tumbleweed Repositories
-        zypper rr repo-oss repo-non-oss repo-update
+        #zypper rr repo-oss repo-non-oss repo-update
         # Add repos
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/oss/ repo-oss
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/non-oss/ repo-non-oss
-        zypper ar -f https://ftp.gwdg.de/pub/opensuse/update/tumbleweed/ repo-update
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/oss/ repo-oss
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/tumbleweed/repo/non-oss/ repo-non-oss
+        #zypper ar -f https://ftp.gwdg.de/pub/opensuse/update/tumbleweed/ repo-update
 
         # Make the upgrade and install the dependencies needed to run snapd tests
         # In case some repo cannot be updated due to proxy restriction


### PR DESCRIPTION
After some changes in the proxy, we can use the default repos. 

This is not long term solution, that's why the code to setup a repo is still in the tasks.