### PR TITLE
remove secrets inherit in update workflow

### DIFF
--- a/.github/workflows/update_openstack_ps7_amd64.yaml
+++ b/.github/workflows/update_openstack_ps7_amd64.yaml
@@ -9,7 +9,6 @@ jobs:
     name: os-amd64-ps7 (${{ matrix.group }})
     runs-on: [self-hosted, spread-enabled]
     environment: OS_AMD64_PS7
-    secrets: inherit
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
I incorrectly introduced `secrets: inherit` in https://github.com/canonical/spread-images/pull/100